### PR TITLE
Allow getting age of GPS observations

### DIFF
--- a/helpers/s3Helper.js
+++ b/helpers/s3Helper.js
@@ -4,6 +4,9 @@ var zlib = require('zlib');
 
 const s3 = new AWS.S3();
 
+const s3Bucket = process.env.TRYNAPI_S3_BUCKET || "orion-vehicles";
+console.log(`Reading state from s3://${s3Bucket}`);
+
 /*
  * Gets bucket prefix at the minute-level
  * @param agency - String
@@ -23,7 +26,7 @@ function getBucketMinutePrefix(agency, currentTime) {
 function getS3Paths(prefix) {
   return new Promise((resolve, reject) => {
     s3.listObjects({
-      Bucket: "orion-vehicles",
+      Bucket: s3Bucket,
       Prefix: prefix,
     }, (err, data) => {
       if (err) {
@@ -67,7 +70,7 @@ async function getS3Vehicles(keys) {
   return _.flatten(await Promise.all(keys.map(key => {
       return new Promise((resolve, reject) => {
         s3.getObject({
-          Bucket: "orion-vehicles",
+          Bucket: s3Bucket,
           Key: key,
         }, (err, data) => {
           if (err) {

--- a/resolvers.js
+++ b/resolvers.js
@@ -4,7 +4,7 @@ const makePointReliabilities = require('./helpers/makePointReliabilities');
 const s3Helper = require('./helpers/s3Helper.js');
 const _ = require('lodash');
 
-const isRawRestbusData = process.env.TRYNAPI_S3_BUCKET == 'orion-raw';
+const isRawRestbusData = process.env.TRYNAPI_S3_BUCKET === 'orion-raw';
 
 if (isRawRestbusData) {
     console.log("S3 objects interpreted as raw Restbus data");

--- a/resolvers.js
+++ b/resolvers.js
@@ -4,6 +4,12 @@ const makePointReliabilities = require('./helpers/makePointReliabilities');
 const s3Helper = require('./helpers/s3Helper.js');
 const _ = require('lodash');
 
+const isRawRestbusData = process.env.TRYNAPI_S3_BUCKET == 'orion-raw';
+
+if (isRawRestbusData) {
+    console.log("S3 objects interpreted as raw Restbus data");
+}
+
 const resolvers = {
     Query: {
         trynState: async (obj, params) => {
@@ -21,9 +27,11 @@ const resolvers = {
 
             // group the vehicles by route, and then by time
             const vehiclesByRouteByTime = vehicles.reduce((acc, vehicle) => {
-                acc[vehicle.rid] = acc[vehicle.rid] || [];
-                acc[vehicle.rid][vehicle.vtime] = acc[vehicle.rid][vehicle.vtime] || [];
-                acc[vehicle.rid][vehicle.vtime].push(vehicle);
+                const routeId = isRawRestbusData ? vehicle.routeId : vehicle.rid;
+                const vtime = vehicle.vtime;
+                acc[routeId] = acc[routeId] || [];
+                acc[routeId][vtime] = acc[routeId][vtime] || [];
+                acc[routeId][vtime].push(vehicle);
                 return acc;
             }, {});
 
@@ -74,6 +82,15 @@ const resolvers = {
                 return [];
             }
         }
+    },
+
+    Vehicle: {
+        vid: vehicle => (isRawRestbusData ? vehicle.id : vehicle.vid),
+        did: vehicle => (isRawRestbusData ? vehicle.directionId : vehicle.did),
+        lat: vehicle => vehicle.lat,
+        lon: vehicle => vehicle.lon,
+        heading: vehicle => vehicle.heading,
+        secsSinceReport: vehicle => vehicle.secsSinceReport,
     }
 };
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -4,6 +4,7 @@ type Vehicle {
     lat: Float
     lon: Float
     heading: Int
+    secsSinceReport: Int
 }
 
 type PrevVehicle {


### PR DESCRIPTION
Here secsSinceReport is returned as a new vehicle field. The client can subtract secsSinceReport from vtime/1000 to get the time associated with the lat/lon observation (https://github.com/trynmaps/metrics-mvp/blob/master/models/eclipses.py#L30). 

An alternative approach would be for tryn-api to subtract secsSinceReport*1000 from vtime instead of adding a new field. 

- allow configuring s3 bucket via environment variable, to allow getting secsSinceReport before it starts being recorded in orion-vehicles
- handle different data format in orion-raw bucket