### PR TITLE
fix bug where filtered buses are returned with vtime 0,1,2,... instead of actual vtime

### DIFF
--- a/helpers/removeMuniMetroDuplicates.js
+++ b/helpers/removeMuniMetroDuplicates.js
@@ -117,11 +117,11 @@ const resolveLeaderlessFollowers = (
  * in the Nextbus feed. A leadingVehicleID is also included, and is used
  * to remove follower vehicles from the API result, returning only the
  * leading vehicle with a numCars field.
- * 
+ *
  * - Once vehicle A is the leading vehicle of B, that pairing will remain
  *   for the vid/rid/did combination of the leading vehicle for all states
  *   being processed by the API; see addPairings for more context.
- * 
+ *
  * - As to have consistent vehicle IDs, if a follower is present without
  *   its leader, it becomes the leader (vid and numCars fields are set).
  *   See resolveLeaderlessFollowers for more context.
@@ -136,7 +136,10 @@ const removeMuniMetroDuplicates = vehiclesByTime => {
     console.log('Follower -> Leader');
     console.log(followerToLeader);
   }
-  return Object.keys(vehiclesByTime).map(time => {
+
+  let filteredVehicles = {};
+
+  Object.keys(vehiclesByTime).map(time => {
     let vehicles = vehiclesByTime[time];
     // leading vehicles in the state have numCars added to them
     const {
@@ -161,10 +164,11 @@ const removeMuniMetroDuplicates = vehiclesByTime => {
         .filter(vehicle => pairedFollowersMap[makeVehicleKey(vehicle)])
         .map(vehicle => makeVehicleKey(vehicle)));
     }
-    vehicles = vehicles.filter(vehicle =>
+    filteredVehicles[time] = vehicles.filter(vehicle =>
       !pairedFollowersMap[makeVehicleKey(vehicle)]);
-    return vehicles;
   });
+
+  return filteredVehicles;
 };
 
 module.exports = removeMuniMetroDuplicates;


### PR DESCRIPTION
Updated the removeMuniMetroDuplicates function to return an object with vtime keys instead of an array. Tested computing arrivals with this fix applied and the follower vehicles appear to be filtered out correctly.

KT headways on 2019-06-06 removing duplicates (stop 7346):
```
count              = 109
average headway    = 11.6 min
standard deviation = 9.9 min
shortest headway   = 0.2 min
10% headway        = 2.7 min
median headway     = 7.9 min
90% headway        = 26.9 min
longest headway    = 36.6 min
```

KT headways on 2019-06-06 without removing duplicates:
```
count              = 149
average headway    = 8.5 min
standard deviation = 9.9 min
shortest headway   = 0.0 min
10% headway        = 0.1 min
median headway     = 4.6 min
90% headway        = 24.5 min
longest headway    = 36.5 min 
```