### PR TITLE
add LoadBalancer service for kubernetes

### DIFF
--- a/kubernetes/tryn-api-service.yaml
+++ b/kubernetes/tryn-api-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    run: tryn-api
+  name: tryn-api
+spec:
+  ports:
+  - protocol: "TCP"
+    port: 80
+    targetPort: 4000
+  selector:
+    run: tryn-api
+  type: LoadBalancer


### PR DESCRIPTION
I just used a LoadBalancer service which only supports HTTP, although alternatively could use an ingress with a GKE managed SSL certificate like the `web` service.

Within the GKE cluster, the GraphQL service is available at http://tryn-api/graphql which avoids sending traffic over the public IP.