### PR TITLE
merge nearby vehicles with the same GTFS trip ID (fixes TriMet MAX stats); add stopId to GraphQL API

### DIFF
--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -36,6 +36,7 @@ const resolvers = {
                     vehiclesByRouteByTime[routeId][vtime] = [];
                 }
 
+                // check for multiple vehicles with the same tripId, assume to be multiple-car trains if close to each other
                 const tripId = vehicle.tripId;
                 if (tripId) {
                     if (!vehiclesByTripByTime[tripId]) {
@@ -45,7 +46,7 @@ const resolvers = {
                     if (!prevVehicle) {
                         vehiclesByTripByTime[tripId][vtime] = vehicle;
                     } else if (Math.abs(prevVehicle.lat - vehicle.lat) < 0.001 && Math.abs(prevVehicle.lon - vehicle.lon) < 0.001) {
-                        //console.log("multi-car vehicle for trip " + tripId + " at "+vtime+" : " + vehicle.vid + " " + prevVehicle.vid);
+                        // 0.001 degrees latitude = 111m, 0.001 degrees longitude typically between between ~50m and 111m
                         prevVehicle.numCars = (prevVehicle.numCars || 1) + 1;
                         if (prevVehicle.vid > vehicle.vid) {
                             prevVehicle.vid = vehicle.vid;

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -10,6 +10,7 @@ type VehicleState {
     numCars: Int
     tripId: String
     stopIndex: Int
+    stopId: String
     status: Int
 }
 


### PR DESCRIPTION
The metrics for TriMet MAX routes have been incorrect because TriMet's GTFS-Realtime API returns two vehicles for each MAX train. Each vehicle in the GTFS realtime API has the same trip ID (based on the static GTFS feed), and appears to have identical GPS coordinates. This PR updates tryn-api to combine these vehicles into one vehicle with the number of cars in the numCars field, similarly to how it already works for Muni Metro routes.

Unlike the Nextbus API, the GTFS-Realtime API does not specify which is the "leading" vehicle. To ensure that the same vehicle ID is always returned, the GraphQL API always returns the first vehicle ID alphabetically.

I'm not sure if there would ever be a case where an agency would run multiple vehicles with the same GTFS trip ID that are actually independent vehicles. To avoid combining vehicles in that case, this PR only combines vehicles if they are within 0.001 degrees latitude and 0.001 degrees longitude (roughly 100m radius).

This PR also adds the stopId field to the GraphQL API. GTFS-Realtime APIs may provide the ID of the stop that the vehicle is currently stopped at or approaching. The metrics backend currently does not use the GTFS-Realtime stop ID to determine when vehicles arrive at a stop, but it might be useful in the future.